### PR TITLE
Adding schedule action.

### DIFF
--- a/Wrapper/MailjetWrapper.php
+++ b/Wrapper/MailjetWrapper.php
@@ -20,7 +20,7 @@ class MailjetWrapper
     var $secure = true;
     
     // Mode debug ? 0 : none; 1 : errors only; 2 : all
-    var $debug = 1;
+    var $debug = 0;
 
     public function __construct($mailjetApiKey, $mailjetSecretKey)
     {

--- a/Wrapper/MailjetWrapper.php
+++ b/Wrapper/MailjetWrapper.php
@@ -20,7 +20,7 @@ class MailjetWrapper
     var $secure = true;
     
     // Mode debug ? 0 : none; 1 : errors only; 2 : all
-    var $debug = 0;
+    var $debug = 1;
 
     public function __construct($mailjetApiKey, $mailjetSecretKey)
     {
@@ -97,6 +97,7 @@ class MailjetWrapper
             $request = 'GET';
         // Request ID, empty by default
         $id = isset($params["ID"]) ? $params["ID"] : '';
+
         /*
           Using SendAPI without the "to" parameter but with "cc" AND/OR "bcc"
           Our API needs the "to" parameter filled to send email
@@ -134,7 +135,10 @@ class MailjetWrapper
                 $newsletter_id = $params['ID'];
             }
             $this->call_url = "https://api.mailjet.com/v3/DATA/NewsLetter/" . $newsletter_id . "/HTML/text/html/LAST";
-        } else {
+        }  else if($resource == "schedule"){
+             $newsletter_id = $params['ID'];
+             $this->call_url = $this->apiUrl."/newsletter/".$newsletter_id."/schedule";
+        }else {
             $this->call_url = $this->apiUrl . '/' . $resource;
         }
         if ($request == "GET") {
@@ -186,7 +190,14 @@ class MailjetWrapper
                 curl_setopt($curl_handle, CURLOPT_HTTPHEADER, array(
                     'Content-Type: text/html'
                 ));
-            } else {
+            } else if($resource == "schedule"){
+                unset($params['ID']);
+                curl_setopt($curl_handle, CURLOPT_POSTFIELDS, json_encode($params));
+                curl_setopt($curl_handle, CURLOPT_HTTPHEADER, array(
+                    'Content-Type: application/json'
+                ));
+            }
+             else {
                 curl_setopt($curl_handle, CURLOPT_POSTFIELDS, json_encode($params));
                 curl_setopt($curl_handle, CURLOPT_HTTPHEADER, array(
                     'Content-Type: application/json'
@@ -200,6 +211,7 @@ class MailjetWrapper
         if ($request == 'PUT') {
             curl_setopt($curl_handle, CURLOPT_CUSTOMREQUEST, "PUT");
         }
+
         $buffer = curl_exec($curl_handle);
         if ($this->debug == 2) {
             var_dump($buffer);
@@ -215,12 +227,12 @@ class MailjetWrapper
             $this->_response = json_decode($buffer, false, 512, JSON_BIGINT_AS_STRING);
         }
         if ($request == 'POST') {
-            return ($this->_response_code == 201) ? true : false;
+            return ($this->_response_code == 201 || $this->_response_code == 200) ? true : false;
         }
         if ($request == 'DELETE') {
-            return ($this->_response_code == 204) ? true : false;
+            return ($this->_response_code == 204 || $this->_response_code == 200) ? true : false;
         }
-        return ($this->_response_code == 200) ? true : false;
+        return ($this->_response_code == 200 || $this->_response_code == 200) ? true : false;
     }
 
     public function debug()


### PR DESCRIPTION
Hi.

I was working with the Bundle, and I found that I need to schedule campaigns, but from the basic bundle wasn't possible, so I'd added a few lines to allow it.

Now you can schedule your campaigns easily, here is a snnipet for testing.

``` php
public function scheduleCampaignAction($nid){
        $mailjet = $this->container->get('headoo_mailjet_wrapper');
        $params = array(
            'method' => 'POST',
            'ID' => $nid,
            'date' => "2015-04-22T09:00:00+01:00"
        );

        return new JsonResponse($mailjet->schedule($params));
    }
```

Also in the response from the API I've added the reading on the status code, because if you expect 201, or more detailed ones, you always get false as return.

Hope you found useful and you can include it on the bundle.

Regards.
